### PR TITLE
Missing py version

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,7 +6,8 @@
   "project_description": "This is my click command-line app project.",
   "python_version": [
     "3.6",
-    "3.7"
+    "3.7",
+    "3.8"
   ],
   "author_name": "my_name",
   "author_email": "my_email",

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
-make venv && source venv/bin/activate && make install && make build
+
+if ! make venv; then
+    echo ""
+    echo -e "\e[1m\e[31mCannot create the virtual environment.\e[0m"
+    echo ""
+    echo -e "\e[1mIs python version {{cookiecutter.python_version}} installed?\e[0m"
+    echo ""
+    echo -e "\033[1m\033[4mNext Steps\033[0m"
+    echo -e "Install python version {{cookiecutter.python_version}}."
+    echo -e "Run cookiecutter again."
+    echo ""
+    exit 1
+else
+    source venv/bin/activate && make install && make build
+fi
 
 cat << "PYTHON"
                  .-------------------------.


### PR DESCRIPTION
The post-generation hook now fails (with some context messaging) if `make venv` fails.