### PR TITLE
Added python3 virtualenv option.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,6 +9,10 @@
     "3.7",
     "3.8"
   ],
+  "virtualenv": [
+    "virtualenv",
+    "python3"
+  ],
   "sphinx_theme": [
     "alabaster",
     "readthedocs"

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -3,6 +3,9 @@
 PROJ_SLUG = {{cookiecutter.package_name}}
 CLI_NAME = {{cookiecutter.cli_name}}
 PY_VERSION = {{cookiecutter.python_version}}
+{% if cookiecutter.virtualenv == 'python3' %}
+SHELL = bash
+{% endif %}
 
 
 build:
@@ -52,7 +55,13 @@ clean :
 	coverage erase
 
 venv :
+{% if cookiecutter.virtualenv == 'virtualenv' %}
 	virtualenv --python python$(PY_VERSION) venv
+{% endif %}
+{% if cookiecutter.virtualenv == 'python3' %}
+	python3 -m venv venv
+	source venv/bin/activate && pip install pip --upgrade --index-url=https://pypi.org/simple
+{% endif %}
 
 install:
 	pip install -r requirements.txt


### PR DESCRIPTION
I've added an option to the cookiecutter.json variables to allow a user to pick between `virtualenv` and `python3 -m venv venv` when creating the virtual environment.  (I know of an environment that uses gemfury as the repo which fails when using virtualenv, possibly because pip is out of date.  It may be a problem on the repo side, but using the other command and updating pip seems to do the trick and seems generally applicable.)