### PR TITLE
Removed extra 'html_theme' line from Sphinx conf.py.

### DIFF
--- a/{{cookiecutter.project_name}}/docs/source/conf.py
+++ b/{{cookiecutter.project_name}}/docs/source/conf.py
@@ -120,8 +120,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
-html_theme = "sphinx_rtd_theme"
+
 # fmt: off
 {% if cookiecutter.sphinx_theme == 'alabaster'%}  # noqa
 # fmt: on


### PR DESCRIPTION
I noticed that the Shinx conf.py was always setting `html_theme` to `sphinx_rtd_theme`, then re-setting it to the selected theme.  It's not critical, but was a little confusing when I reviewed the generated `conf.py` so  I removed the extraneous line.