### PR TITLE
fix so that "make test" doesn't fail immediately after installing

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/cli.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/cli.py
@@ -72,7 +72,7 @@ def cli(info: Info, verbose: int):
 @pass_info
 def hello(_: Info):
     """Say 'hello' to the nice people."""
-    click.echo(f"{{cookiecutter.cli_name}} says 'hello'")
+    click.echo("{{cookiecutter.cli_name}} says 'hello'")
 
 
 @cli.command()


### PR DESCRIPTION
this is the error:
clickcli\cli.py:75:16: F541 f-string is missing placeholders